### PR TITLE
Add explicit supercsv dependency as was removed from C* in 3.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,8 @@ apply plugin: 'java'
 sourceCompatibility = 1.7
 version = '1.0'
 
-def cassandra_version = '2.1.0'
+def cassandra_version = '2.1.12'
+def supercsv_version = '2.1.0'
 
 repositories {
     mavenLocal()
@@ -12,6 +13,7 @@ repositories {
 
 dependencies {
     compile group: 'org.apache.cassandra', name: 'cassandra-all', version: cassandra_version
+    compile group: 'net.sf.supercsv', name: 'super-csv', version: supercsv_version
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }
 


### PR DESCRIPTION
supercsv was removed as a dependency from cassandra in 3.0 by [CASSANDRA-9035](https://issues.apache.org/jira/browse/CASSANDRA-9035).

By adding it as an explicit dependency everything seems to work great with 3.X.
